### PR TITLE
Modified DateTimeParse for the case when explicit time is not present

### DIFF
--- a/src/main/java/seedu/taskmanager/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/taskmanager/logic/commands/AddCommand.java
@@ -59,7 +59,7 @@ public class AddCommand extends Command {
             endDate = new DummyEndTaskDate();
 
         } else {
-            endDate = new TaskDate(DateTimeUtil.parseDateTime(endDateString));
+            endDate = new TaskDate(DateTimeUtil.parseEndDateTime(endDateString));
         }
 
         for (String tagName : tags) {

--- a/src/main/java/seedu/taskmanager/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/taskmanager/logic/commands/AddCommand.java
@@ -52,7 +52,7 @@ public class AddCommand extends Command {
             startDate = new DummyStartTaskDate();
 
         } else {
-            startDate = new TaskDate(DateTimeUtil.parseDateTime(startDateString));
+            startDate = new TaskDate(DateTimeUtil.parseStartDateTime(startDateString));
         }
 
         if (endDateString == NO_END_DATE) {

--- a/src/main/java/seedu/taskmanager/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/taskmanager/logic/parser/AddCommandParser.java
@@ -82,8 +82,8 @@ public class AddCommandParser {
         String startDateString = argsTokenizer.getValue(PREFIX_STARTDATE).get();
         String endDateString = argsTokenizer.getValue(PREFIX_ENDDATE).get();
 
-        Date startDate = DateTimeUtil.parseDateTime(startDateString);
-        Date endDate = DateTimeUtil.parseDateTime(endDateString);
+        Date startDate = DateTimeUtil.parseStartDateTime(startDateString);
+        Date endDate = DateTimeUtil.parseEndDateTime(endDateString);
 
         return startDate.before(endDate);
     }

--- a/src/main/java/seedu/taskmanager/logic/parser/DateTimeUtil.java
+++ b/src/main/java/seedu/taskmanager/logic/parser/DateTimeUtil.java
@@ -2,6 +2,7 @@ package seedu.taskmanager.logic.parser;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -21,7 +22,7 @@ public class DateTimeUtil {
     public static final String EMPTY_STRING = "";
 
     private static final int FIRST_ELEMENT_INDEX = 0;
-    private static final int SECOND_ELEMENT_INDEX = 1;
+    private static final String TIME_SYNTAX = "EXPLICIT_TIME";
 
 
     // Used to store and print date to end user.
@@ -32,6 +33,7 @@ public class DateTimeUtil {
 
     private static Parser dateTimeParser = new Parser(TimeZone.getDefault());
 
+    //General date/time parses for string with both date and time elements
     public static Date parseDateTime(String date) throws IllegalValueException {
         List<DateGroup> parsedDates = dateTimeParser.parse(date);
 
@@ -42,17 +44,55 @@ public class DateTimeUtil {
             throw new IllegalValueException(INVALID_DATE_FORMAT);
         }
     }
+    
+    //Specialized date/time parser for startDate string with only date element
+    //Set time of the returned date object as the starting time of the day
+    //i.e. 00:00 am
+    public static Date parseStartDateTime(String startDate) throws IllegalValueException {
+    	List<DateGroup> parsedStartDatesList = dateTimeParser.parse(startDate);
+
+    	if (isValidArg(parsedStartDatesList)) {
+
+    		DateGroup parsedStartDate = parsedStartDatesList.get(FIRST_ELEMENT_INDEX);
+    		String syntaxTreeString = parsedStartDate.getSyntaxTree().getChild(FIRST_ELEMENT_INDEX).toStringTree();
+    		
+    		if (!isTimePresent(syntaxTreeString)) {
+    			return setStartDateTime(parsedStartDate.getDates().get(FIRST_ELEMENT_INDEX));
+    		}
+    		return parsedStartDate.getDates().get(FIRST_ELEMENT_INDEX);
+
+    	} else {
+    		throw new IllegalValueException(INVALID_DATE_FORMAT);
+    	}
+    }
 
     public static String getStringFromDate(Date date) {
         DateFormat dateFormat = new SimpleDateFormat(DATE_STRING_FORMAT);
         return dateFormat.format(date);
     }
 
-    private static boolean isValidArg(List<DateGroup> parsedDates) {
-        if (parsedDates != null && !parsedDates.isEmpty()) {
+    //Check if the DateGroup argument input is valid
+    private static boolean isValidArg(List<DateGroup> parsedDatesList) {
+        if (parsedDatesList != null && !parsedDatesList.isEmpty()) {
                 return true;
         } else {
                 return false;
         }
+    }
+    
+    //Check if explicit time is present in the syntax tree
+    private static boolean isTimePresent(String syntaxTreeString) {
+    	return syntaxTreeString.contains(TIME_SYNTAX);
+    }
+    
+    //Set time of the returned Date object as the starting time of the day
+    //i.e. 00:00:00
+    private static Date setStartDateTime(Date date) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        return cal.getTime();
     }
 }

--- a/src/main/java/seedu/taskmanager/logic/parser/DateTimeUtil.java
+++ b/src/main/java/seedu/taskmanager/logic/parser/DateTimeUtil.java
@@ -20,8 +20,12 @@ public class DateTimeUtil {
     public static final String INVALID_DATE_FORMAT = "Date format is not accepted by PotaTodo";
     public static final String EMPTY_STRING = "";
 
+    private static final int FIRST_ELEMENT_INDEX = 0;
+    private static final int SECOND_ELEMENT_INDEX = 1;
+
+
     // Used to store and print date to end user.
-    public final static String DATE_STRING_FORMAT = "dd MMMMM yyyy, hh:mm aaa";
+    public static final String DATE_STRING_FORMAT = "dd MMMMM yyyy, hh:mm aaa";
 
     public DateTimeUtil() {
     };
@@ -31,8 +35,8 @@ public class DateTimeUtil {
     public static Date parseDateTime(String date) throws IllegalValueException {
         List<DateGroup> parsedDates = dateTimeParser.parse(date);
 
-        if (parsedDates != null && !parsedDates.isEmpty()) {
-            return parsedDates.get(0).getDates().get(0);
+        if (isValidArg(parsedDates)) {
+            return parsedDates.get(FIRST_ELEMENT_INDEX).getDates().get(FIRST_ELEMENT_INDEX);
 
         } else {
             throw new IllegalValueException(INVALID_DATE_FORMAT);
@@ -42,5 +46,13 @@ public class DateTimeUtil {
     public static String getStringFromDate(Date date) {
         DateFormat dateFormat = new SimpleDateFormat(DATE_STRING_FORMAT);
         return dateFormat.format(date);
+    }
+
+    private static boolean isValidArg(List<DateGroup> parsedDates) {
+        if (parsedDates != null && !parsedDates.isEmpty()) {
+                return true;
+        } else {
+                return false;
+        }
     }
 }

--- a/src/main/java/seedu/taskmanager/logic/parser/DateTimeUtil.java
+++ b/src/main/java/seedu/taskmanager/logic/parser/DateTimeUtil.java
@@ -21,9 +21,15 @@ public class DateTimeUtil {
     public static final String INVALID_DATE_FORMAT = "Date format is not accepted by PotaTodo";
     public static final String EMPTY_STRING = "";
 
-    private static final int FIRST_ELEMENT_INDEX = 0;
     private static final String TIME_SYNTAX = "EXPLICIT_TIME";
+    private static final int FIRST_ELEMENT_INDEX = 0;
 
+    private static final int STARTING_TIME_HOUR = 0;
+    private static final int STARTING_TIME_MINUTE = 0;
+    private static final int STARTING_TIME_SECOND = 0;
+    private static final int ENDING_TIME_HOUR = 23;
+    private static final int ENDING_TIME_MINUTE = 59;
+    private static final int ENDING_TIME_SECOND = 59;
 
     // Used to store and print date to end user.
     public static final String DATE_STRING_FORMAT = "dd MMMMM yyyy, hh:mm aaa";
@@ -111,9 +117,9 @@ public class DateTimeUtil {
     private static Date setStartDateTime(Date date) {
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);
-        cal.set(Calendar.HOUR_OF_DAY, 0);
-        cal.set(Calendar.MINUTE, 0);
-        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.HOUR_OF_DAY, STARTING_TIME_HOUR);
+        cal.set(Calendar.MINUTE, STARTING_TIME_MINUTE);
+        cal.set(Calendar.SECOND, STARTING_TIME_SECOND);
         return cal.getTime();
     }
 
@@ -122,9 +128,9 @@ public class DateTimeUtil {
     private static Date setEndDateTime(Date date) {
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);
-        cal.set(Calendar.HOUR_OF_DAY, 23);
-        cal.set(Calendar.MINUTE, 59);
-        cal.set(Calendar.SECOND, 59);
+        cal.set(Calendar.HOUR_OF_DAY, ENDING_TIME_HOUR);
+        cal.set(Calendar.MINUTE, ENDING_TIME_MINUTE);
+        cal.set(Calendar.SECOND, ENDING_TIME_SECOND);
         return cal.getTime();
     }
 }

--- a/src/main/java/seedu/taskmanager/logic/parser/DateTimeUtil.java
+++ b/src/main/java/seedu/taskmanager/logic/parser/DateTimeUtil.java
@@ -47,7 +47,7 @@ public class DateTimeUtil {
     
     //Specialized date/time parser for startDate string with only date element
     //Set time of the returned date object as the starting time of the day
-    //i.e. 00:00 am
+    //i.e. 00:00:00 am
     public static Date parseStartDateTime(String startDate) throws IllegalValueException {
     	List<DateGroup> parsedStartDatesList = dateTimeParser.parse(startDate);
 
@@ -60,6 +60,27 @@ public class DateTimeUtil {
     			return setStartDateTime(parsedStartDate.getDates().get(FIRST_ELEMENT_INDEX));
     		}
     		return parsedStartDate.getDates().get(FIRST_ELEMENT_INDEX);
+
+    	} else {
+    		throw new IllegalValueException(INVALID_DATE_FORMAT);
+    	}
+    }
+
+    //Specialized date/time parser for endDate string with only date element
+    //Set time of the returned date object as the ending time of the day
+    //i.e. 11:59:59 pm
+    public static Date parseEndDateTime(String endDate) throws IllegalValueException {
+    	List<DateGroup> parsedEndDatesList = dateTimeParser.parse(endDate);
+
+    	if (isValidArg(parsedEndDatesList)) {
+
+    		DateGroup parsedEndDate = parsedEndDatesList.get(FIRST_ELEMENT_INDEX);
+    		String syntaxTreeString = parsedEndDate.getSyntaxTree().getChild(FIRST_ELEMENT_INDEX).toStringTree();
+    		
+    		if (!isTimePresent(syntaxTreeString)) {
+    			return setEndDateTime(parsedEndDate.getDates().get(FIRST_ELEMENT_INDEX));
+    		}
+    		return parsedEndDate.getDates().get(FIRST_ELEMENT_INDEX);
 
     	} else {
     		throw new IllegalValueException(INVALID_DATE_FORMAT);
@@ -93,6 +114,17 @@ public class DateTimeUtil {
         cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
+        return cal.getTime();
+    }
+
+    //Set time of the returned Date object as the starting time of the day
+    //i.e. 00:00:00
+    private static Date setEndDateTime(Date date) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        cal.set(Calendar.HOUR_OF_DAY, 23);
+        cal.set(Calendar.MINUTE, 59);
+        cal.set(Calendar.SECOND, 59);
         return cal.getTime();
     }
 }

--- a/src/main/java/seedu/taskmanager/logic/parser/DateTimeUtil.java
+++ b/src/main/java/seedu/taskmanager/logic/parser/DateTimeUtil.java
@@ -123,8 +123,8 @@ public class DateTimeUtil {
         return cal.getTime();
     }
 
-    //Set time of the returned Date object as the starting time of the day
-    //i.e. 00:00:00
+    //Set time of the returned Date object as the ending time of the day
+    //i.e. 23:59:59
     private static Date setEndDateTime(Date date) {
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);

--- a/src/main/java/seedu/taskmanager/logic/parser/DateTimeUtil.java
+++ b/src/main/java/seedu/taskmanager/logic/parser/DateTimeUtil.java
@@ -12,7 +12,7 @@ import com.joestelmach.natty.Parser;
 import seedu.taskmanager.commons.exceptions.IllegalValueException;
 
 /**
- * Natty parser
+ * Natty date parser that parses a command with date and time and return a Date object
  */
 
 public class DateTimeUtil {

--- a/src/main/java/seedu/taskmanager/storage/XmlAdaptedTask.java
+++ b/src/main/java/seedu/taskmanager/storage/XmlAdaptedTask.java
@@ -67,8 +67,8 @@ public class XmlAdaptedTask {
             taskTags.add(tag.toModelType());
         }
         final Name name = new Name(this.name);
-        final TaskDate startDate = new TaskDate(DateTimeUtil.parseDateTime(this.startDate));
-        final TaskDate endDate = new TaskDate(DateTimeUtil.parseDateTime(this.endDate));
+        final TaskDate startDate = new TaskDate(DateTimeUtil.parseStartDateTime(this.startDate));
+        final TaskDate endDate = new TaskDate(DateTimeUtil.parseEndDateTime(this.endDate));
         final UniqueTagList tags = new UniqueTagList(taskTags);
         return new Task(name, startDate, endDate, tags);
     }

--- a/src/test/java/seedu/taskmanager/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/taskmanager/logic/LogicManagerTest.java
@@ -345,8 +345,8 @@ public class LogicManagerTest {
          * Generates a Task object with given name, start and end dates.
          */
         Task generateTaskWithAll(String name, String startDate, String endDate) throws Exception {
-            return new Task(new Name(name), new TaskDate(DateTimeUtil.parseDateTime(startDate)),
-                    new TaskDate(DateTimeUtil.parseDateTime(endDate)), new UniqueTagList(new Tag("tag")));
+            return new Task(new Name(name), new TaskDate(DateTimeUtil.parseStartDateTime(startDate)),
+                    new TaskDate(DateTimeUtil.parseEndDateTime(endDate)), new UniqueTagList(new Tag("tag")));
         }
     }
 }

--- a/src/test/java/seedu/taskmanager/testutil/TypicalTestTasks.java
+++ b/src/test/java/seedu/taskmanager/testutil/TypicalTestTasks.java
@@ -43,28 +43,28 @@ public class TypicalTestTasks {
     public TypicalTestTasks() {
         try {
             event1 = new TaskBuilder().withName(EVENT1_NAME)
-                    .withStartDate(new TaskDate(DateTimeUtil.parseDateTime(EVENT1_START_DATE_STRING)))
-                    .withEndDate(new TaskDate(DateTimeUtil.parseDateTime(EVENT1_END_DATE_STRING))).withTags("important")
+                    .withStartDate(new TaskDate(DateTimeUtil.parseStartDateTime(EVENT1_START_DATE_STRING)))
+                    .withEndDate(new TaskDate(DateTimeUtil.parseEndDateTime(EVENT1_END_DATE_STRING))).withTags("important")
                     .build();
             event2 = new TaskBuilder().withName(EVENT2_NAME)
-                    .withStartDate(new TaskDate(DateTimeUtil.parseDateTime(EVENT2_START_DATE_STRING)))
-                    .withEndDate(new TaskDate(DateTimeUtil.parseDateTime(EVENT2_END_DATE_STRING))).build();
+                    .withStartDate(new TaskDate(DateTimeUtil.parseStartDateTime(EVENT2_START_DATE_STRING)))
+                    .withEndDate(new TaskDate(DateTimeUtil.parseEndDateTime(EVENT2_END_DATE_STRING))).build();
 
             ddl1 = new TaskBuilder().withName(DDL1_NAME)
-                    .withEndDate(new TaskDate(DateTimeUtil.parseDateTime(DDL1_DUE_TIME_STRING))).withTags("urgent")
+                    .withEndDate(new TaskDate(DateTimeUtil.parseEndDateTime(DDL1_DUE_TIME_STRING))).withTags("urgent")
                     .withTags("dying").build();
             ddl2 = new TaskBuilder().withName(DDL2_NAME)
-                    .withEndDate(new TaskDate(DateTimeUtil.parseDateTime(DDL2_DUE_TIME_STRING))).build();
+                    .withEndDate(new TaskDate(DateTimeUtil.parseEndDateTime(DDL2_DUE_TIME_STRING))).build();
 
             flt1 = new TaskBuilder().withName(FLT1_NAME).withTags("essential").build();
             flt2 = new TaskBuilder().withName(FLT2_NAME).withTags("easy").build();
 
             // Manually add only
             event3 = new TaskBuilder().withName(EVENT3_NAME)
-                    .withStartDate(new TaskDate(DateTimeUtil.parseDateTime(EVENT3_START_DATE_STRING)))
-                    .withEndDate(new TaskDate(DateTimeUtil.parseDateTime(EVENT3_END_DATE_STRING))).build();
+                    .withStartDate(new TaskDate(DateTimeUtil.parseStartDateTime(EVENT3_START_DATE_STRING)))
+                    .withEndDate(new TaskDate(DateTimeUtil.parseEndDateTime(EVENT3_END_DATE_STRING))).build();
             ddl3 = new TaskBuilder().withName(DDL3_NAME)
-                    .withEndDate(new TaskDate(DateTimeUtil.parseDateTime(DDL3_DUE_TIME_STRING))).build();
+                    .withEndDate(new TaskDate(DateTimeUtil.parseEndDateTime(DDL3_DUE_TIME_STRING))).build();
             flt3 = new TaskBuilder().withName(FLT3_NAME).withTags("hard").withTags("daunting").build();
 
         } catch (IllegalValueException e) {


### PR DESCRIPTION
Issue #55 & #89 
Changed parseDateTime method to 1. parseStartDateTime and 2. parseEndDateTime
1. -> set time to 00:00:00 if explicit start time is not present
2. -> set time to 23:59:59 if explicit end time is not present